### PR TITLE
Add a GeoURI formatter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,13 @@
-name: Test
+# This workflow will build a Swift project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
+
+name: Swift
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -13,19 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Setup Swift
-      uses: swift-actions/setup-swift@v1.15.0
-      with:
-        swift-version: "5.6.1"
     - name: Build
-      run: swift build --disable-sandbox -v
-    - name: Build documentation
-      uses: fwcd/swift-docc-action@v1.0.2
-      with:
-        target: LocationFormatter
-        output: ./docs
-        hosting-base-path: LocationFormatter
-        disable-indexing: 'true'
-        transform-for-static-hosting: 'true'
+      run: swift build -v
     - name: Run tests
       run: swift test -v

--- a/Sources/LocationFormatter/CoordinateFormat.swift
+++ b/Sources/LocationFormatter/CoordinateFormat.swift
@@ -20,6 +20,11 @@ public enum CoordinateFormat: String {
     
     /// Universal Transverse Mercator (UTM).
     case utm
+    
+    /// GeoURI.
+    ///
+    /// A Uniform Resource Identifier for Geographic Locations ('geo' URI).
+    case geoURI
 }
 
 extension CoordinateFormat: CustomStringConvertible {

--- a/Sources/LocationFormatter/DegreesFormat.swift
+++ b/Sources/LocationFormatter/DegreesFormat.swift
@@ -79,7 +79,7 @@ extension DegreesFormat {
             self = .degreesDecimalMinutes
         case .degreesMinutesSeconds:
             self = .degreesMinutesSeconds
-        case .utm:
+        case .utm, .geoURI:
             return nil
         }
     }

--- a/Sources/LocationFormatter/DisplayOptions.swift
+++ b/Sources/LocationFormatter/DisplayOptions.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Display options
 public struct DisplayOptions: OptionSet {
     /// Use a suffix to to represent the cardinal direction of the coordinate.
@@ -13,7 +11,7 @@ public struct DisplayOptions: OptionSet {
     ///
     /// - Important: Only applies if the SymbolStyle is not `.none`.
     public static let compact = Self(rawValue: 1 << 1)
-
+    
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }

--- a/Sources/LocationFormatter/Extensions/CLLocation.swift
+++ b/Sources/LocationFormatter/Extensions/CLLocation.swift
@@ -1,0 +1,41 @@
+import CoreLocation
+
+extension CLLocation {
+    /// Indicates the amount of uncertainty in the location as a value in meters.
+    ///
+    /// This is intended to correlate the `horizontalAccuracy` and `verticalAccuracy`
+    /// properties of `CLLocation` to the `GeoURI` location uncertainty parameter defined
+    /// in [section-3.4.3](https://datatracker.ietf.org/doc/html/rfc5870#section-3.4.3).
+    ///
+    /// A `nil` value indicates that the uncertainty is unknown.
+    ///
+    /// - Note: A value of zero has different meanings in `CoreLocation` and the `GeoURI` specification,
+    /// so the implementations cannot match exactly.
+    public var uncertainty: CLLocationAccuracy? {
+        switch (horizontalUncertainty, verticalUncertainty) {
+        case (.none, .none):
+            return nil
+        case (.some(let h), .none):
+            return h
+        case (.none, .some(let v)):
+            return v
+        case (.some(let h), .some(let v)):
+            return max(h, v)
+        }
+    }
+    
+    var horizontalUncertainty: CLLocationAccuracy? {
+        guard horizontalAccuracy > .zero else { return nil }
+        return horizontalAccuracy
+    }
+    
+    var verticalUncertainty: CLLocationAccuracy? {
+        guard verticalAccuracy > .zero, altitude != .zero else { return nil }
+        return verticalAccuracy
+    }
+    
+    convenience init(coordinate: CLLocationCoordinate2D) {
+        self.init(latitude: coordinate.latitude, longitude: coordinate.longitude)
+    }
+}
+

--- a/Sources/LocationFormatter/Extensions/CLLocationCoordinate2D.swift
+++ b/Sources/LocationFormatter/Extensions/CLLocationCoordinate2D.swift
@@ -35,6 +35,25 @@ public extension CLLocationCoordinate2D {
      the International Space Station when it passes overhead.
     */
     static let pointNemo = Self(latitude: -49.0273, longitude: -123.4345)
+    
+    /// Returns a new CLLocationCoordinate2D with a "normalized" longitude value.
+    ///
+    /// These transformations ate based on those defined in the [URI Comparison](https://datatracker.ietf.org/doc/html/rfc5870#section-3.4.4)
+    /// section of the `GeoURI` specification.
+    ///
+    /// - Longitude values corresponding to the international dateline (-180° and 180°) will be represented as 180.0, 
+    /// as they both identify the same physical longitude.
+    /// - The longitude values of polar locations, 90° or -90° latitude, will be converted to 0.0 as all longitudes are 0° at the poles.
+    func normalized() -> CLLocationCoordinate2D {
+        // International dateline - -180 and 180 are identical, so prefer 180.
+        var normalizedLongitude = longitude == -180.0 ? 180.0 : longitude
+        // longitude is zero at the poles
+        if latitude == -90.0 || latitude == 90.0 {
+            normalizedLongitude = .zero
+        }
+        
+        return CLLocationCoordinate2D(latitude: latitude, longitude: normalizedLongitude)
+    }
 }
 
 extension CLLocationCoordinate2D: Equatable {

--- a/Sources/LocationFormatter/Formatters/GeoURILocationFormatter+CLLocationCoordinate2D.swift
+++ b/Sources/LocationFormatter/Formatters/GeoURILocationFormatter+CLLocationCoordinate2D.swift
@@ -1,0 +1,16 @@
+import CoreLocation
+
+extension GeoURILocationFormatter {
+    /// Returns a `GeoURI` string representation of the provided `CLLocationCoordinate2D`.
+    public func string(fromCoordinate coordinate: CLLocationCoordinate2D) -> String? {
+        let location = CLLocation(coordinate: coordinate)
+        return string(fromLocation: location)
+    }
+    
+    /// Returns a `CLLocationCoordinate2D` created by parsing a `GeoURI` string.
+    ///
+    /// A ``ParsingError`` is thrown if the string is not a valid GeoURI.
+    public func coordinate(from string: String) throws -> CLLocationCoordinate2D {
+        try location(from: string).coordinate
+    }
+}

--- a/Sources/LocationFormatter/Formatters/GeoURILocationFormatter.swift
+++ b/Sources/LocationFormatter/Formatters/GeoURILocationFormatter.swift
@@ -1,0 +1,175 @@
+import Foundation
+import CoreLocation
+
+/** A formatter that converts between `CLLocation` objects and their `GeoURI` representations.
+
+ [RFC5870](https://datatracker.ietf.org/doc/html/rfc5870) specifies a Uniform Resource Identifier (URI)
+ for geographic locations using the 'geo' scheme name.  A 'geo' URI identifies a physical location
+ in a two- or three-dimensional coordinate reference system in a compact, simple, human-readable,
+ and protocol-independent way.
+ 
+  - Note: The default coordinate reference system used is the [World Geodetic System 1984](https://earth-info.nga.mil/?dir=wgs84&action=wgs84) (WGS-84).
+*/
+public final class GeoURILocationFormatter: Formatter {
+    
+    /// Options for parsing coordinates strings.
+    ///
+    /// Default options include `ParsingOptions.caseInsensitive`.
+    public var parsingOptions: ParsingOptions = [.caseInsensitive]
+    
+    /// Options for converting between `CLLocation` objects and GeoURI strings.
+    public var options: GeoURIFormatOptions = [.normalizeLongitude]
+    
+    /// Returns a `GeoURI` string representation of a `CLLocation` object.
+    public func string(fromLocation location: CLLocation) -> String? {
+        return string(for: location)
+    }
+    
+    /// Returns a `CLLocation` object created by parsing a `GeoURI` string.
+    ///
+    /// A ``ParsingError`` is thrown if the string is not a valid `GeoURI`.
+    public func location(from string: String) throws -> CLLocation {
+        
+        var geoURI = parsingOptions.contains(.trimmed) ? string.trimmingCharacters(in: .whitespacesAndNewlines) : string
+        
+        if parsingOptions.contains(.caseInsensitive) {
+            geoURI = geoURI.lowercased()
+        }
+                
+        var components = geoURI.components(separatedBy: ";")
+        
+        let baseUri = components.removeFirst()
+        
+        let prefix = "geo:"
+        
+        guard baseUri.hasPrefix(prefix) else {
+            throw ParsingError.noMatch
+        }
+        
+        let pathComponents = baseUri
+            .dropFirst(prefix.count)
+            .components(separatedBy: ",")
+        
+        guard (2...3).contains(pathComponents.count) else {
+            throw ParsingError.noMatch
+        }
+        
+        guard pathComponents.indices.contains(0), let latitude = Double(pathComponents[0]) else {
+            throw ParsingError.noMatch
+        }
+        
+        guard pathComponents.indices.contains(1), let longitude = Double(pathComponents[1]) else {
+            throw ParsingError.noMatch
+        }
+        
+        var altitude: Double? = nil
+        if pathComponents.indices.contains(2) {
+            guard let altVal = Double(pathComponents[2]) else {
+                throw ParsingError.noMatch
+            }
+            altitude = altVal
+        }
+
+        var coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        
+        if options.contains(.normalizeLongitude) {
+            coordinate = coordinate.normalized()
+        }
+        
+        guard CLLocationCoordinate2DIsValid(coordinate) else { throw ParsingError.invalidCoordinate }
+                
+        let queryComponents = components
+            .map { $0.lowercased() }
+            .map { $0.components(separatedBy: "=") }
+            .filter { $0.count == 2 }
+            .map { ($0[0], $0[1]) }
+        
+        let params = Dictionary(queryComponents, uniquingKeysWith: { (first, _) in first })
+        
+        if let crs = params["crs"] {
+            guard crs.caseInsensitiveCompare("wgs84") == .orderedSame else {
+                throw ParsingError.unsupportedCoordinateReferenceSystem(crs: crs)
+            }
+        }
+        
+        var uncertainty: Double = .zero
+        if let uval = params["u"], let doubleUval = Double(uval) {
+            uncertainty = doubleUval
+        }
+
+        return CLLocation(
+            coordinate: coordinate,
+            altitude: altitude ?? .zero,
+            horizontalAccuracy: uncertainty,
+            verticalAccuracy: altitude != nil ? uncertainty : .zero,
+            timestamp: Date()
+        )
+    }
+    
+    // MARK: - Formatter
+
+    override public func string(for obj: Any?) -> String? {
+        
+        guard let location = obj as? CLLocation else { return nil }
+        
+        let coordinate = options.contains(.normalizeLongitude) ? location.coordinate.normalized() : location.coordinate
+        
+        guard CLLocationCoordinate2DIsValid(coordinate), location.horizontalAccuracy >= .zero else {
+            return nil
+        }
+        
+        var pathComponents = [location.coordinate.latitude, location.coordinate.longitude]
+        
+        if location.verticalAccuracy > .zero {
+            pathComponents.append(location.altitude)
+        }
+        
+        let path = pathComponents
+            .compactMap { Self.numberFormatter.string(from: NSDecimalNumber(value: $0)) }
+            .joined(separator: ",")
+        
+        var desc =  "geo:\(path)"
+        
+        if options.contains(.includeCRS) {
+            desc.append(";crs=wgs84")
+        }
+        
+        if let uncertainty = location.uncertainty, let uVal = Self.numberFormatter.string(from: NSDecimalNumber(value: uncertainty)) {
+            desc.append(";u=\(uVal)")
+        }
+        
+        return desc
+    }
+    
+    override public func getObjectValue(
+        _ obj: AutoreleasingUnsafeMutablePointer<AnyObject?>?,
+        for string: String,
+        errorDescription error: AutoreleasingUnsafeMutablePointer<NSString?>?
+    ) -> Bool {
+        do {
+            let location = try location(from: string)
+            obj?.pointee = location
+            return obj?.pointee != nil
+        } catch let err {
+            error?.pointee = err.localizedDescription as NSString
+            return false
+        }
+    }
+    
+    // MARK: - Internal
+    
+    static var numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.generatesDecimalNumbers = true
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 11
+        formatter.decimalSeparator = "."
+        formatter.positivePrefix = ""
+        formatter.negativePrefix = "-"
+        formatter.hasThousandSeparators = false
+        formatter.localizesFormat = false
+        return formatter
+    }()
+}
+

--- a/Sources/LocationFormatter/Formatters/LocationCoordinateFormatter.swift
+++ b/Sources/LocationFormatter/Formatters/LocationCoordinateFormatter.swift
@@ -42,6 +42,7 @@ public final class LocationCoordinateFormatter: Formatter {
 
     private lazy var degreesFormatter = LocationDegreesFormatter()
     private lazy var utmFormatter = UTMCoordinateFormatter()
+    private lazy var geoUriFormatter = GeoURILocationFormatter()
 
     // MARK: - Configuration
 
@@ -107,6 +108,8 @@ public final class LocationCoordinateFormatter: Formatter {
             return degreeString(from: coordinate)
         case .utm:
             return utmFormatter.string(from: coordinate)
+        case .geoURI:
+            return geoUriFormatter.string(fromCoordinate: coordinate)
         }
     }
 
@@ -117,6 +120,8 @@ public final class LocationCoordinateFormatter: Formatter {
             return try coordinateFrom(degreesString: string)
         case .utm:
             return try utmFormatter.coordinate(from: string)
+        case .geoURI:
+            return try geoUriFormatter.coordinate(from: string)
         }
     }
 
@@ -150,7 +155,7 @@ public final class LocationCoordinateFormatter: Formatter {
             degreesFormatter.format = .degreesDecimalMinutes
         case .degreesMinutesSeconds:
             degreesFormatter.format = .degreesMinutesSeconds
-        case .utm:
+        case .utm, .geoURI:
             break
         }
     }
@@ -165,6 +170,8 @@ public final class LocationCoordinateFormatter: Formatter {
             degreesFormatter.displayOptions = options
         case .utm:
             utmFormatter.displayOptions = options
+        case .geoURI:
+            break
         }
     }
 
@@ -178,6 +185,8 @@ public final class LocationCoordinateFormatter: Formatter {
             degreesFormatter.parsingOptions = options
         case .utm:
             utmFormatter.parsingOptions = options
+        case .geoURI:
+            geoUriFormatter.parsingOptions = options
         }
     }
 
@@ -290,4 +299,16 @@ public extension LocationCoordinateFormatter {
    ```
     */
     static let utmFormatter = LocationCoordinateFormatter(format: .utm)
+    
+    /**
+     A LocationCoordinateFormatter configured to use the GeoURI format.
+    
+   ```swift
+   let coordinate = CLLocationCoordinate2D(latitude: 48.11638, longitude: -122.77527)
+   let formatter = LocationCoordinateFormatter.geoUriFormatter
+   formatter.string(from: coordinate)
+   // "geo:48.11638,-122.77527"
+   ```
+    */
+    static let geoUriFormatter = LocationCoordinateFormatter(format: .geoURI)
 }

--- a/Sources/LocationFormatter/Formatters/LocationDegreesFormatter.swift
+++ b/Sources/LocationFormatter/Formatters/LocationDegreesFormatter.swift
@@ -70,7 +70,7 @@ public final class LocationDegreesFormatter: Formatter {
     
     /// The maximum number of digits after the decimal separator for degrees.
     ///
-    /// The default value is 5, which is accurate to 1.1132 meters (3.65 feet).
+    /// The default value is 5, which is accurate to 1.1132 meters (3.65 feet) at the equator.
     ///
     /// - Important: Only applicable if `format` is `DegreesFormat.decimalDegrees`.
     public var maximumDegreesFractionDigits = 5

--- a/Sources/LocationFormatter/GeoURIFormatOptions.swift
+++ b/Sources/LocationFormatter/GeoURIFormatOptions.swift
@@ -1,0 +1,13 @@
+/// Options affecting how `CLLocation` objects are converted between their GeoURI representations.
+public struct GeoURIFormatOptions: OptionSet {
+    /// Normalize longitude values when converting between location objects and GeoURI strings.
+    public static let normalizeLongitude = Self(rawValue: 1 << 0)
+    /// Include the Coordinate Reference System (CRS) parameter in GeoURI strings representations.
+    public static let includeCRS = Self(rawValue: 1 << 1)
+    
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public let rawValue: Int
+}

--- a/Sources/LocationFormatter/LocationFormatter.docc/Extensions/GeoURILocationFormatter.md
+++ b/Sources/LocationFormatter/LocationFormatter.docc/Extensions/GeoURILocationFormatter.md
@@ -1,0 +1,44 @@
+# ``LocationFormatter/GeoURILocationFormatter``
+
+## Examples
+
+A basic GeoURI containing a two dimensional coordinate:
+```
+geo:48.11638,-122.77527
+```
+
+A three dimensional coordinate:
+```
+geo:48.11638,-122.77527
+```
+
+Parameters that represent the coordinate reference system (crs) and uncertainty (u):
+```
+geo:11.373333,142.591667,-10920;crs=wgs84;u=10
+```
+
+## Topics
+
+### Configuring Formatter Behavior and Style
+
+- ``GeoURIFormatOptions``
+- ``ParsingOptions``
+
+### Parsing a GeoURI string.
+
+- ``GeoURILocationFormatter/location(from:)``
+- ``GeoURILocationFormatter/coordinate(from:)``
+
+###  Generating a GeoURI string.
+
+- ``GeoURILocationFormatter/string(fromLocation:)``
+- ``GeoURILocationFormatter/string(fromCoordinate:)``
+
+### Formatter methods
+
+- ``GeoURILocationFormatter/string(for:)``
+- ``GeoURILocationFormatter/getObjectValue(_:for:errorDescription:)``
+
+### Errors
+
+- ``ParsingError``

--- a/Sources/LocationFormatter/LocationFormatter.docc/LocationFormatter.md
+++ b/Sources/LocationFormatter/LocationFormatter.docc/LocationFormatter.md
@@ -18,6 +18,7 @@ Coordinates can be parsed from strings in any ``CoordinateFormat``, and accordin
 - ``LocationCoordinateFormatter``
 - ``LocationDegreesFormatter``
 - ``UTMCoordinateFormatter``
+- ``GeoURILocationFormatter``
 
 ### Display configuration
 

--- a/Sources/LocationFormatter/ParsingError.swift
+++ b/Sources/LocationFormatter/ParsingError.swift
@@ -33,5 +33,7 @@ public enum ParsingError: Error, Equatable {
     
     /// The named string was not found.
     case notFound(name: String)
+    
+    /// The named coordinate references system (CRS) is not supported.
+    case unsupportedCoordinateReferenceSystem(crs: String)
 }
-

--- a/Sources/LocationFormatter/ParsingOptions.swift
+++ b/Sources/LocationFormatter/ParsingOptions.swift
@@ -1,15 +1,14 @@
-import Foundation
-
 /// Options affecting how a coordinate is parsed from a string.
 public struct ParsingOptions: OptionSet {
     /// Disregard case when matching strings.
     public static let caseInsensitive = Self(rawValue: 1 << 0)
     /// Ignore whitespace at the beginning and end of the string.
     public static let trimmed = Self(rawValue: 1 << 1)
-
+    
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
 
     public let rawValue: Int
 }
+

--- a/Tests/LocationFormatterTests/CLLocationCoordinate2DTests.swift
+++ b/Tests/LocationFormatterTests/CLLocationCoordinate2DTests.swift
@@ -1,0 +1,38 @@
+import CoreLocation
+import XCTest
+@testable import LocationFormatter
+
+
+final class CLLocationCoordinate2DTests: XCTestCase {
+
+    func testDatelineNormalization() {
+        var coordinate: CLLocationCoordinate2D = .pointNemo
+        var normalized = coordinate.normalized()
+        XCTAssertEqual(-48.876667, normalized.latitude)
+        XCTAssertEqual(-123.393333, normalized.longitude)
+        
+        coordinate = CLLocationCoordinate2D(latitude: -48.876667, longitude: 180)
+        normalized = coordinate.normalized()
+        XCTAssertEqual(-48.876667, normalized.latitude)
+        XCTAssertEqual(180.0, normalized.longitude)
+        
+        coordinate = CLLocationCoordinate2D(latitude: -48.876667, longitude: -180)
+        normalized = coordinate.normalized()
+        XCTAssertEqual(-48.876667, normalized.latitude)
+        XCTAssertEqual(180.0, normalized.longitude)
+    }
+    
+    func testPolarLongitude() {
+        var actual = CLLocationCoordinate2D.pointNemo.normalized()
+        XCTAssertEqual(-48.876667, actual.latitude)
+        XCTAssertEqual(-123.393333, actual.longitude)
+        
+        actual = CLLocationCoordinate2D(latitude: 90, longitude: -123.393333).normalized()
+        XCTAssertEqual(90.0, actual.latitude)
+        XCTAssertEqual(.zero, actual.longitude)
+        
+        actual = CLLocationCoordinate2D(latitude: -90, longitude: -123.393333).normalized()
+        XCTAssertEqual(-90.0, actual.latitude)
+        XCTAssertEqual(.zero, actual.longitude)
+    }
+}

--- a/Tests/LocationFormatterTests/CLLocationTests.swift
+++ b/Tests/LocationFormatterTests/CLLocationTests.swift
@@ -1,0 +1,129 @@
+import CoreLocation
+import XCTest
+@testable import LocationFormatter
+
+final class CLLocationTests: XCTestCase {
+
+    func testHorizontalUncertainty() {
+        var location = CLLocation(coordinate: .pointNemo)
+        XCTAssertNil(location.horizontalUncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 0,
+            horizontalAccuracy: 1.23,
+            verticalAccuracy: 0,
+            timestamp: Date()
+        )
+        XCTAssertEqual(1.23, location.horizontalUncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: Date()
+        )
+        XCTAssertNil(location.horizontalUncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 0,
+            horizontalAccuracy: -1.23,
+            verticalAccuracy: 0,
+            timestamp: Date()
+        )
+        XCTAssertNil(location.horizontalUncertainty)
+    }
+    
+    func testVerticalUncertainty() {
+        var location = CLLocation(coordinate: .pointNemo)
+        XCTAssertNil(location.verticalUncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 1.23,
+            timestamp: Date()
+        )
+        XCTAssertNil(location.verticalUncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 66.6,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 1.23,
+            timestamp: Date()
+        )
+        XCTAssertEqual(1.23, location.verticalUncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 66.6,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: Date()
+        )
+        XCTAssertNil(location.verticalUncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 66.6,
+            horizontalAccuracy: 0,
+            verticalAccuracy: -1.23,
+            timestamp: Date()
+        )
+        XCTAssertNil(location.verticalUncertainty)
+    }
+    
+    func testUncertainty() {
+        var location = CLLocation(coordinate: .pointNemo)
+        XCTAssertNil(location.uncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 999,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 0,
+            timestamp: Date()
+        )
+        XCTAssertNil(location.uncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 999,
+            horizontalAccuracy: 1.23,
+            verticalAccuracy: 0,
+            timestamp: Date()
+        )
+        XCTAssertEqual(1.23, location.uncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 999,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 4.56,
+            timestamp: Date()
+        )
+        XCTAssertEqual(4.56, location.uncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 0,
+            horizontalAccuracy: 0,
+            verticalAccuracy: 4.56,
+            timestamp: Date()
+        )
+        XCTAssertNil(location.uncertainty)
+        
+        location = CLLocation(
+            coordinate: .pointNemo,
+            altitude: 999,
+            horizontalAccuracy: 1.23,
+            verticalAccuracy: 4.56,
+            timestamp: Date()
+        )
+        XCTAssertEqual(4.56, location.uncertainty)
+    }
+}

--- a/Tests/LocationFormatterTests/Formatters/GeoURILocationFormatterTests.swift
+++ b/Tests/LocationFormatterTests/Formatters/GeoURILocationFormatterTests.swift
@@ -1,0 +1,320 @@
+import CoreLocation
+@testable import LocationFormatter
+import XCTest
+
+final class GeoURILocationFormatterTests: XCTestCase {
+    
+    private var formatter: GeoURILocationFormatter!
+    
+    override func setUpWithError() throws {
+        formatter = GeoURILocationFormatter()
+        try super.setUpWithError()
+    }
+    
+    override func tearDownWithError() throws {
+        formatter = nil
+        try super.tearDownWithError()
+    }
+    
+    // MARK: - String Generation
+
+    func testStringFromLocation() {
+        XCTAssertEqual("geo:27.988056,86.925278,8848.86;u=0.21", formatter.string(fromLocation: .mountEverest))
+        XCTAssertEqual("geo:11.373333,142.591667,-10920;u=10", formatter.string(fromLocation: .challengerDeep))
+        XCTAssertEqual("geo:-48.876667,-123.393333", formatter.string(fromLocation: .pointNemo))
+    }
+    
+    func testIncludeCRS() {
+        formatter.options.insert(.includeCRS)
+        
+        XCTAssertEqual("geo:27.988056,86.925278,8848.86;crs=wgs84;u=0.21", formatter.string(fromLocation: .mountEverest))
+        XCTAssertEqual("geo:11.373333,142.591667,-10920;crs=wgs84;u=10", formatter.string(fromLocation: .challengerDeep))
+        XCTAssertEqual("geo:-48.876667,-123.393333;crs=wgs84", formatter.string(fromLocation: .pointNemo))
+        
+        XCTAssertEqual("geo:48.11638,-122.77527;crs=wgs84", formatter.string(fromCoordinate: .portTownsend))
+        XCTAssertEqual("geo:-55.97917,-67.275;crs=wgs84", formatter.string(fromCoordinate: .capeHorn))
+        XCTAssertEqual("geo:-4.67785,55.46718;crs=wgs84", formatter.string(fromCoordinate: .seychelles))
+        XCTAssertEqual("geo:62.06323,-6.87355;crs=wgs84", formatter.string(fromCoordinate: .faroeIslands))
+        XCTAssertEqual("geo:51.37363,179.41535;crs=wgs84", formatter.string(fromCoordinate: .amchitkaIsland))
+    }
+    
+    func testStringFromCoordinate() {
+        XCTAssertEqual("geo:48.11638,-122.77527", formatter.string(fromCoordinate: .portTownsend))
+        XCTAssertEqual("geo:-55.97917,-67.275", formatter.string(fromCoordinate: .capeHorn))
+        XCTAssertEqual("geo:-4.67785,55.46718", formatter.string(fromCoordinate: .seychelles))
+        XCTAssertEqual("geo:62.06323,-6.87355", formatter.string(fromCoordinate: .faroeIslands))
+        XCTAssertEqual("geo:51.37363,179.41535", formatter.string(fromCoordinate: .amchitkaIsland))
+    }
+    
+    
+    
+    // MARK: - String Parsing
+    
+    func testLocationFromString() throws {
+        var actual = try formatter.location(from: "geo:27.988056,86.925278,8848.86;u=0.21")
+        XCTAssertEqual(27.988056, actual.coordinate.latitude)
+        XCTAssertEqual(86.925278, actual.coordinate.longitude)
+        XCTAssertEqual(8_848.86, actual.altitude)
+        XCTAssertEqual(0.21, actual.horizontalAccuracy)
+        XCTAssertEqual(0.21, actual.verticalAccuracy)
+        
+        actual = try formatter.location(from: "geo:11.373333,142.591667,-10920;crs=wgs84;u=10")
+        XCTAssertEqual(11.373333, actual.coordinate.latitude)
+        XCTAssertEqual(142.591667, actual.coordinate.longitude)
+        XCTAssertEqual(-10_920, actual.altitude)
+        XCTAssertEqual(10.0, actual.horizontalAccuracy)
+        XCTAssertEqual(10.0, actual.verticalAccuracy)
+        
+        actual = try formatter.location(from: "geo:-48.876667,-123.393333;crs=wgs84")
+        XCTAssertEqual(-48.876667, actual.coordinate.latitude)
+        XCTAssertEqual(-123.393333, actual.coordinate.longitude)
+        XCTAssertEqual(.zero, actual.altitude)
+        XCTAssertEqual(.zero, actual.horizontalAccuracy)
+        XCTAssertEqual(.zero, actual.verticalAccuracy)
+    }
+    
+    // MARK: Scheme
+    
+    func testScheme() throws {
+        // string should begin with the 'geo:' scheme
+        var geoURI = "48.11638,-122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo48.11638,-122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo://48.11638,-122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = " geo:48.11638,-122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        // should be case insensitive
+        geoURI = "GEO:48.11638,-122.77527"
+        
+        XCTAssertNoThrow(try formatter.location(from: geoURI))
+    }
+    
+    // MARK: Latitude
+    
+    func testLatitudeParsing() throws {
+        var geoURI = "geo:"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo:,-122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo: 48.11638,-122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+          XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo:48.11638 ,-122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo:xy.z,-122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo123.45, -122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+    }
+    
+    func testLatitudeRange() throws {
+        var geoURI = "geo:90,-122.77527"
+        var location = try formatter.location(from: geoURI)
+        XCTAssertEqual(90.0, location.coordinate.latitude)
+        
+        geoURI = "geo:90.0000000001,-122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .invalidCoordinate)
+        }
+        
+        geoURI = "geo:-90,-122.77527"
+        location = try formatter.location(from: geoURI)
+        XCTAssertEqual(-90.0, location.coordinate.latitude)
+        
+        geoURI = "geo:-90.0000000001,-122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .invalidCoordinate)
+        }
+    }
+    
+    // MARK: Longitude
+    
+    func testLongitudeParsing() throws {
+        var geoURI = "geo:48.11638"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo:48.11638,"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo:48.11638, -122.77527"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo:48.11638,XXX"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo:48.11638,1234.56,"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+    }
+    
+    func testLongitudeRange() throws {
+        formatter.options = [] // ensure normalizeLongitude is not an option
+
+        var geoURI = "geo:48.11638,180"
+        var location = try formatter.location(from: geoURI)
+        XCTAssertEqual(180.0, location.coordinate.longitude)
+        
+        geoURI = "geo:48.11638,180.00000000001"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .invalidCoordinate)
+        }
+        
+        geoURI = "geo:48.11638,-180"
+        location = try formatter.location(from: geoURI)
+        XCTAssertEqual(-180.0, location.coordinate.longitude)
+        
+        geoURI = "geo:48.11638,-180.00000000001"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .invalidCoordinate)
+        }
+    }
+    
+    func testLongitudeNormalization() throws {
+        formatter.options = [.normalizeLongitude]
+        
+        // dateline normalization
+        var geoURI = "geo:48.11638,-180"
+        var location = try formatter.location(from: geoURI)
+        XCTAssertEqual(180.0, location.coordinate.longitude)
+        
+        geoURI = "geo:90,-122.77527"
+        location = try formatter.location(from: geoURI)
+        XCTAssertEqual(0, location.coordinate.longitude)
+        
+        geoURI = "geo:-90,-122.77527"
+        location = try formatter.location(from: geoURI)
+        XCTAssertEqual(0, location.coordinate.longitude)
+    }
+    
+    // MARK: Altitude
+    
+    func testAltitudeParsing() throws {
+        
+        formatter.parsingOptions = []
+        
+        var geoURI = "geo:48.11638,-122.77527"
+        var location = try formatter.location(from: geoURI)
+        XCTAssertEqual(.zero, location.altitude)
+        
+        geoURI = "geo:48.11638,-122.77527,0"
+        location = try formatter.location(from: geoURI)
+        XCTAssertEqual(.zero, location.altitude)
+        
+        geoURI = "geo:48.11638,-122.77527,1.23"
+        location = try formatter.location(from: geoURI)
+        XCTAssertEqual(1.23, location.altitude)
+        
+        geoURI = "geo:48.11638,-122.77527,-1.23"
+        location = try formatter.location(from: geoURI)
+        XCTAssertEqual(-1.23, location.altitude)
+        
+        geoURI = "geo:48.11638,-122.77527,"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo:48.11638,-122.77527, 0"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo:48.11638,-122.77527,1.23 "
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+        
+        geoURI = "geo:48.11638,-122.77527,xyz"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .noMatch)
+        }
+    }
+    
+    // MARK: CRS
+    
+    func testCrsParameter() throws {
+        // If parameter is supplied, pattern should match
+        var geoURI = "geo:48.11638,-122.77527;crs=wgs84"
+        XCTAssertNoThrow(try formatter.location(from: geoURI))
+        
+        // Parameter name should be case insensitive
+        geoURI = "geo:48.11638,-122.77527;CRS=wgs84"
+        XCTAssertNoThrow(try formatter.location(from: geoURI))
+
+        // Parameter value should be case insensitive
+        geoURI = "geo:48.11638,-122.77527;crs=WGS84"
+        XCTAssertNoThrow(try formatter.location(from: geoURI))
+
+        geoURI = "geo:48.11638,-122.77527;crs=nad27"
+        XCTAssertThrowsError(try formatter.location(from: geoURI)) { error in
+            XCTAssertEqual(error as? ParsingError, .unsupportedCoordinateReferenceSystem(crs: "nad27"))
+        }
+    }
+    
+    // MARK: Uncertainty
+    
+    func testUncertaintyParameter() throws {
+        var geoURI = "geo:48.11638,-122.77527;u=66.6"
+        var location = try formatter.location(from: geoURI)
+        XCTAssertEqual(66.6, location.horizontalAccuracy)
+        XCTAssertEqual(.zero, location.verticalAccuracy)
+        
+        geoURI = "geo:48.11638,-122.77527,0;u=66.6"
+        location = try formatter.location(from: geoURI)
+        XCTAssertEqual(66.6, location.horizontalAccuracy)
+        XCTAssertEqual(66.6, location.verticalAccuracy)
+        
+        geoURI = "geo:48.11638,-122.77527,123.45;u=66.6"
+        location = try formatter.location(from: geoURI)
+        XCTAssertEqual(66.6, location.horizontalAccuracy)
+        XCTAssertEqual(66.6, location.verticalAccuracy)
+        
+        // Parameter name should be case insensitive
+        geoURI = "geo:48.11638,-122.77527;U=66.6"
+        location = try formatter.location(from: geoURI)
+        XCTAssertEqual(66.6, location.horizontalAccuracy)
+        XCTAssertEqual(.zero, location.verticalAccuracy)
+        
+        // An invalid value should not throw an error
+        geoURI = "geo:48.11638,-122.77527;u=very"
+        XCTAssertNoThrow(try formatter.location(from: geoURI))
+    }
+}

--- a/Tests/LocationFormatterTests/LocationTestHelpers.swift
+++ b/Tests/LocationFormatterTests/LocationTestHelpers.swift
@@ -28,4 +28,25 @@ extension CLLocationCoordinate2D {
     static let seychelles = CLLocationCoordinate2D(latitude: -4.67785, longitude: 55.46718)
     static let faroeIslands = CLLocationCoordinate2D(latitude: 62.06323, longitude: -6.87355)
     static let amchitkaIsland = CLLocationCoordinate2D(latitude: 51.37363, longitude: 179.41535)
+    static let pointNemo = CLLocationCoordinate2D(latitude: -48.876667, longitude: -123.393333)
+}
+
+extension CLLocation {    
+    static let mountEverest = CLLocation(
+        coordinate: CLLocationCoordinate2D(latitude: 27.988056, longitude: 86.925278),
+        altitude: 8848.86,
+        horizontalAccuracy: 0,
+        verticalAccuracy: 0.21,
+        timestamp: Date()
+    )
+    
+    static let challengerDeep = CLLocation(
+        coordinate: CLLocationCoordinate2D(latitude: 11.373333, longitude: 142.591667),
+        altitude: -10920,
+        horizontalAccuracy: 0.0,
+        verticalAccuracy: 10.0,
+        timestamp: Date()
+    )
+    
+    static let pointNemo = CLLocation(coordinate: .pointNemo)
 }


### PR DESCRIPTION
This PR add a new formatter that converts between `CLLocation` types and their `GeoURI` representations as defined by [rfc5870](https://datatracker.ietf.org/doc/html/rfc5870).

You can verify this in the [Swift REPL](https://www.swift.org/blog/swiftpm-repl-support/)

```
% swift run --repl
Building for debugging...
[2/2] Compiling plugin Swift-DocC Preview
Build complete! (0.19s)
Launching Swift REPL with arguments: repl -I/Users/jeffj/Developer/sss/LocationFormatter/.build/arm64-apple-macosx/debug -L/Users/jeffj/Developer/sss/LocationFormatter/.build/arm64-apple-macosx/debug -llocationformatter__REPL
Welcome to Apple Swift version 5.9.2 (swiftlang-5.9.2.2.56 clang-1500.1.0.2.5).
Type :help for assistance.
  1> import LocationFormatter
  2> import CoreLocation
  3> let formatter = GeoURILocationFormatter()
  4> let location = formatter.location(from: "geo:48.11638,-122.77527")
  5> location.description
$R0: String = "<+48.11638000,-122.77527000> +/- 0.00m (speed -1.00 mps / course -1.00) @ 1/7/24, 12:09:18 Pacific Standard Time"
  6> formatter.string(fromLocation: location)
$R1: String? = "geo:48.11638,-122.77527"

  7> formatter.options.insert(.includeCRS)
  8> formatter.string(fromLocation: location) 
$R3: String? = "geo:48.11638,-122.77527;crs=wgs84"
  9> :quit
```